### PR TITLE
[CHANGE] Limit ESI client to needed operations

### DIFF
--- a/aa_contacts/providers.py
+++ b/aa_contacts/providers.py
@@ -4,7 +4,7 @@ from . import (
     __version__ as app_version,
     __app_name_ua__ as app_name_ua,
     __github_url__ as github_url,
-    __esi_compatibility_date__ as esi_compatibility_date
+    __esi_compatibility_date__ as esi_compatibility_date,
 )
 
 esi = ESIClientProvider(
@@ -12,5 +12,10 @@ esi = ESIClientProvider(
     ua_appname=app_name_ua,
     ua_version=app_version,
     ua_url=github_url,
-    tags=["Contacts"]
+    operations=[
+        "GetAlliancesAllianceIdContacts",
+        "GetAlliancesAllianceIdContactsLabels",
+        "GetCorporationsCorporationIdContacts",
+        "GetCorporationsCorporationIdContactsLabels",
+    ],
 )


### PR DESCRIPTION
5/9 operations in the `Contacts` group are not used, so they don't need to be loaded. Further reduces memory consumption.